### PR TITLE
Fix unit test config path

### DIFF
--- a/tests/unit/map_test.cpp
+++ b/tests/unit/map_test.cpp
@@ -14,9 +14,9 @@ using namespace kvstore;
 class MapTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    std::ifstream config_file("runtime_config.json");
+    std::ifstream config_file("../../src/config/runtime_config.json");
     if (!config_file.is_open()) {
-      std::cerr << "Failed to open runtime_config.json" << std::endl;
+      std::cerr << "Failed to open ../../src/config/runtime_config.json" << std::endl;
       throw std::runtime_error("Could not open config file");
     }
 


### PR DESCRIPTION
## Summary
- open the runtime config file using a path relative to the test binary

## Testing
- `cmake ..` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_685f87236a508328a53a4e33c4f930e6