### PR TITLE
Fix server path in e2e test fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -32,7 +32,7 @@ def server_process(server_port):
     # Build the server if not already built
     base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     build_dir = os.path.join(base_dir, "tests", "unit", "build")
-    server_path = os.path.join(build_dir, "kvstore_server")
+    server_path = os.path.join(build_dir, "server")
     
     if not os.path.exists(server_path):
         # Run cmake first to generate build files


### PR DESCRIPTION
## Summary
- fix the path to the server executable in `tests/e2e/conftest.py`

## Testing
- `python3 -m pytest -q tests/e2e` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_685f871f2398832890b01860e51cbcaf