### PR TITLE
Fix README build dir docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This project implements a key-value store using SPDK and gRPC. It provides a sim
    ```bash
    cmake ..
    ```
+   This step also generates the protobuf and gRPC source files in the
+   `build/` directory.
 
 5. Build the project:
    ```bash
@@ -52,8 +54,8 @@ This project implements a key-value store using SPDK and gRPC. It provides a sim
 
 - `proto/`: Contains the Protocol Buffers definition file (`kvstore.proto`).
 - `src/`: Contains the C++ source files for the server and client.
-- `generated/`: Contains the generated Protocol Buffers and gRPC files.
-- `build/`: Contains the build artifacts.
+- `build/`: Contains the build artifacts. Protobuf and gRPC source files are
+  generated here when CMake configures the project.
 - `third_party/`: Contains external dependencies (gRPC).
 
 ## License


### PR DESCRIPTION
## Summary
- clarify that protobuf and gRPC files are created in the build dir
- remove stale reference to a `generated/` folder

## Testing
- `bash tests/e2e/run_tests.sh` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685f8718d3548328b2a9bc9d435c089e