### PR TITLE
Fix BoostMap iterators and unit test build

### DIFF
--- a/src/map/BoostMap.h
+++ b/src/map/BoostMap.h
@@ -13,10 +13,18 @@ public:
   }
 
   bool insert(const K &key, const V &value) override {
-    return map_.insert(std::make_pair(key, value)).second;
+    auto it = map_.find(key);
+    bool inserted = it == map_.end();
+    map_[key] = value;
+    ordered_map_[key] = value;
+    return inserted;
   }
 
-  bool remove(const K &key) override { return map_.erase(key) > 0; }
+  bool remove(const K &key) override {
+    size_t count = map_.erase(key);
+    ordered_map_.erase(key);
+    return count > 0;
+  }
 
   bool get(const K &key, V &value) const override {
     auto it = map_.find(key);
@@ -33,32 +41,31 @@ public:
 
   size_t size() const override { return map_.size(); }
 
-  void clear() override { map_.clear(); }
+  void clear() override {
+    map_.clear();
+    ordered_map_.clear();
+  }
 
   // Ordered map operations
   typename IMap<K, V>::iterator begin() const override {
-    // Convert boost::container::flat_map iterator to std::map iterator
-    std::map<K, V> temp_map(map_.begin(), map_.end());
-    return temp_map.begin();
+    return ordered_map_.begin();
   }
 
   typename IMap<K, V>::iterator end() const override {
-    std::map<K, V> temp_map(map_.begin(), map_.end());
-    return temp_map.end();
+    return ordered_map_.end();
   }
 
   typename IMap<K, V>::iterator lower_bound(const K &key) const override {
-    std::map<K, V> temp_map(map_.begin(), map_.end());
-    return temp_map.lower_bound(key);
+    return ordered_map_.lower_bound(key);
   }
 
   typename IMap<K, V>::iterator upper_bound(const K &key) const override {
-    std::map<K, V> temp_map(map_.begin(), map_.end());
-    return temp_map.upper_bound(key);
+    return ordered_map_.upper_bound(key);
   }
 
 private:
   boost::container::flat_map<K, V> map_;
-};
+  std::map<K, V> ordered_map_;
+}; 
 
 } // namespace kvstore

--- a/tests/unit/run_tests.sh
+++ b/tests/unit/run_tests.sh
@@ -11,7 +11,7 @@ mkdir -p tests/unit/build
 cd tests/unit/build
 
 # Configure with coverage
-cmake -DCMAKE_BUILD_TYPE=Coverage ../
+cmake -DCMAKE_BUILD_TYPE=Coverage ../../..
 
 # Build
 make -j$(nproc)


### PR DESCRIPTION
## Summary
- fix dangling iterator bug in BoostMap implementation by keeping an ordered std::map
- correct CMake source path in unit test `run_tests.sh`

## Testing
- `tests/unit/run_tests.sh` *(fails: Could NOT find Protobuf)*
- `tests/e2e/run_tests.sh` *(fails: unable to install deps due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e567c2083288919c34bcc895643