### PR TITLE
Add README instructions for running tests

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,0 +1,17 @@
+# Benchmark Tests
+
+This directory contains Go programs used to benchmark the key-value store.
+Results are written to the `results/` folder.
+
+## Running
+
+Use Go 1.21 or newer. From this directory run:
+
+```bash
+go run ./cmd -server localhost:50051 -concurrency 50 -requests 1000
+```
+
+The command accepts flags for the server address, level of concurrency,
+number of requests, path to the `kvstore.proto` file and an optional `tag`
+used to annotate the results. CSV output is placed in the `results/`
+subdirectory.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,17 @@
+# End-to-End Tests
+
+This directory contains the Python end-to-end tests. The `run_tests.sh` script
+creates a virtual environment, installs dependencies, generates the gRPC client
+code and then runs the test suite with `pytest`.
+
+## Running
+
+```bash
+# From the repository root
+cd tests/e2e
+./run_tests.sh
+```
+
+The server binary is built automatically if it does not already exist. Test
+results are shown in the console. The generated gRPC Python files and the
+virtual environment are created locally in this directory.

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,16 @@
+# Unit Tests
+
+This directory contains the C++ unit tests for the key-value store. The `run_tests.sh` script
+builds the test binary using CMake and executes it. Code coverage is generated if `lcov` and `genhtml` are installed.
+
+## Running
+
+```bash
+# From the repository root
+cd tests/unit
+./run_tests.sh
+```
+
+The script creates a `build/` folder inside this directory, compiles the `kvstore_tests`
+executable and then runs it. Coverage results are placed under `build/coverage_report/`
+when the required tools are available.


### PR DESCRIPTION
## Summary
- document how to run unit tests in `tests/unit`
- document how to run e2e tests in `tests/e2e`
- document how to run benchmark tests in `tests/benchmark`

## Testing
- `bash tests/unit/run_tests.sh` *(fails: Could NOT find Protobuf)*
- `bash tests/e2e/run_tests.sh` *(fails: pip install blocked)*
- `go run ./cmd -server localhost:50051 -concurrency 1 -requests 1` *(fails: import is a program, not package)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b92635083289e42cc9aae463778