### PR TITLE
Add configurable WAL factory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ add_executable(kvstore_tests
     tests/unit/server_test.cpp
     tests/unit/map_test.cpp
     tests/unit/block_device_wal_test.cpp
+    tests/unit/wal_factory_test.cpp
     src/server.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}

--- a/src/config/runtime_config.json
+++ b/src/config/runtime_config.json
@@ -8,5 +8,8 @@
         "std_map": {
             "initial_size": 1000
         }
+    },
+    "wal": {
+        "type": "none"
     }
 }

--- a/src/passthrough_wal.h
+++ b/src/passthrough_wal.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "wal.h"
+#include <vector>
+
+class PassThroughWAL : public WAL {
+public:
+  bool append(const WalEntry &) override { return true; }
+  bool appendBatch(const std::vector<WalEntry> &) override { return true; }
+  bool sync() override { return true; }
+  std::vector<WalEntry> replay() override { return {}; }
+  bool rollSegment() override { return true; }
+  bool truncate(uint64_t) override { return true; }
+  uint64_t currentSegmentId() const override { return 0; }
+};

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,6 +1,5 @@
 #include "server_impl.h"
-#include "block_device_wal.h"
-#include "spdk_wal.h"
+#include "wal_factory.h"
 #include <fstream>
 #include <nlohmann/json.hpp>
 
@@ -15,16 +14,7 @@ int main(int argc, char **argv) {
   }
 
   std::string address = config.value("address", "0.0.0.0:50051");
-  std::unique_ptr<WAL> wal;
-  if (config.contains("wal")) {
-    auto w = config["wal"];
-    std::string type = w.value("type", "block");
-    std::string device = w.value("device", "kvstore.wal");
-    if (type == "block")
-      wal = std::make_unique<BlockDeviceWAL>(device);
-    else if (type == "spdk")
-      wal = std::make_unique<SpdkWAL>(device);
-  }
+  std::unique_ptr<WAL> wal = createWAL(config);
 
   AsyncKVServer server(address, std::move(wal));
   server.Run();

--- a/src/wal_factory.h
+++ b/src/wal_factory.h
@@ -9,9 +9,9 @@ inline std::unique_ptr<WAL> createWAL(const nlohmann::json &config) {
   if (!config.contains("wal")) {
     return std::make_unique<PassThroughWAL>();
   }
-  auto w = config["wal"];
-  std::string type = w.value("type", "none");
-  std::string device = w.value("device", "kvstore.wal");
+  auto walConfig = config["wal"];
+  std::string type = walConfig.value("type", "none");
+  std::string device = walConfig.value("device", "kvstore.wal");
   if (type == "block") {
     return std::make_unique<BlockDeviceWAL>(device);
   } else if (type == "spdk") {

--- a/src/wal_factory.h
+++ b/src/wal_factory.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "block_device_wal.h"
+#include "passthrough_wal.h"
+#include "spdk_wal.h"
+#include <memory>
+#include <nlohmann/json.hpp>
+
+inline std::unique_ptr<WAL> createWAL(const nlohmann::json &config) {
+  if (!config.contains("wal")) {
+    return std::make_unique<PassThroughWAL>();
+  }
+  auto w = config["wal"];
+  std::string type = w.value("type", "none");
+  std::string device = w.value("device", "kvstore.wal");
+  if (type == "block") {
+    return std::make_unique<BlockDeviceWAL>(device);
+  } else if (type == "spdk") {
+    return std::make_unique<SpdkWAL>(device);
+  }
+  return std::make_unique<PassThroughWAL>();
+}

--- a/tests/unit/run_tests.sh
+++ b/tests/unit/run_tests.sh
@@ -16,6 +16,9 @@ cmake -DCMAKE_BUILD_TYPE=Coverage ../../..
 # Build
 make -j$(nproc)
 
+# Copy the default runtime config so tests can find it
+cp ../../../src/config/runtime_config.json runtime_config.json
+
 # Run tests
 ./kvstore_tests
 

--- a/tests/unit/wal_factory_test.cpp
+++ b/tests/unit/wal_factory_test.cpp
@@ -1,0 +1,16 @@
+#include "wal_factory.h"
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+TEST(WALFactoryTest, NoneCreatesPassThrough) {
+    nlohmann::json cfg;
+    auto wal = createWAL(cfg);
+    EXPECT_TRUE(dynamic_cast<PassThroughWAL*>(wal.get()) != nullptr);
+}
+
+TEST(WALFactoryTest, BlockCreatesBlockDevice) {
+    nlohmann::json cfg;
+    cfg["wal"] = { {"type", "block"}, {"device", "test.log"} };
+    auto wal = createWAL(cfg);
+    EXPECT_TRUE(dynamic_cast<BlockDeviceWAL*>(wal.get()) != nullptr);
+}


### PR DESCRIPTION
## Summary
- introduce `PassThroughWAL` that implements the WAL interface but does nothing
- add `createWAL` factory to return the right WAL implementation based on config
- use the factory in `server_main.cpp`
- update default config with a `wal` section
- provide unit tests for the new factory
- copy runtime config in test script so unit tests succeed

## Testing
- `./tests/unit/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865cbe436408328ab532caa7dc997cb