### PR TITLE
Fix CSV writer error handling in benchmark

### DIFF
--- a/tests/benchmark/benchlib.go
+++ b/tests/benchmark/benchlib.go
@@ -120,7 +120,11 @@ func writeCSV(filePath string, allResults []Result) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			err = fmt.Errorf("failed to close file: %w", cerr)
+		}
+	}()
 
 	w := csv.NewWriter(f)
 

--- a/tests/benchmark/benchlib.go
+++ b/tests/benchmark/benchlib.go
@@ -123,21 +123,26 @@ func writeCSV(filePath string, allResults []Result) error {
 	defer f.Close()
 
 	w := csv.NewWriter(f)
-	defer w.Flush()
 
 	if err := w.Write([]string{"Method", "LatencyMs", "Error"}); err != nil {
-		return err
+		return fmt.Errorf("failed to write header to CSV: %w", err)
 	}
 	for _, r := range allResults {
 		errStr := ""
 		if r.Error != nil {
 			errStr = r.Error.Error()
 		}
-		w.Write([]string{
+		if err := w.Write([]string{
 			r.Method,
 			fmt.Sprintf("%.2f", r.LatencyMs),
 			errStr,
-		})
+		}); err != nil {
+			return fmt.Errorf("failed to write record to CSV: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("failed to flush CSV writer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- check `csv.Writer` writes for errors
- report errors on flush for benchmarks

## Testing
- `go vet ./...` in `tests/benchmark`
- `go build ./...` in `tests/benchmark`
- `go test ./...` in `tests/benchmark`
- `go vet ./...` in `src_go`
- `go build ./...` in `src_go`
- `go test ./...` in `src_go`


------
https://chatgpt.com/codex/tasks/task_e_6865d8e6dd1c8328969f077a2caac2f4