### PR TITLE
Implement batched WAL writes

### DIFF
--- a/src/block_device_wal.h
+++ b/src/block_device_wal.h
@@ -26,9 +26,35 @@ public:
 
   bool appendBatch(const std::vector<WalEntry> &entries) override {
     std::lock_guard<std::mutex> lock(mu_);
-    for (const auto &e : entries)
-      if (!writeEntry(e))
+
+    // Serialize all entries into a single buffer and issue one write
+    std::vector<char> buffer;
+    buffer.reserve(entries.size() * 32); // rough estimate to minimize realloc
+
+    for (const auto &e : entries) {
+      uint8_t op = static_cast<uint8_t>(e.op_type);
+      uint32_t klen = e.key.size();
+      uint32_t vlen = e.value.size();
+
+      buffer.push_back(static_cast<char>(op));
+      const char *pk = reinterpret_cast<const char *>(&klen);
+      buffer.insert(buffer.end(), pk, pk + sizeof(klen));
+      const char *pv = reinterpret_cast<const char *>(&vlen);
+      buffer.insert(buffer.end(), pv, pv + sizeof(vlen));
+      buffer.insert(buffer.end(), e.key.data(), e.key.data() + klen);
+      if (vlen)
+        buffer.insert(buffer.end(), e.value.data(), e.value.data() + vlen);
+    }
+
+    size_t total = buffer.size();
+    const char *data = buffer.data();
+    while (total > 0) {
+      ssize_t written = ::write(fd_, data, total);
+      if (written <= 0)
         return false;
+      data += written;
+      total -= written;
+    }
     return true;
   }
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -41,8 +41,9 @@ def server_process(server_port):
         subprocess.run(["cmake", "--build", build_dir], check=True)
     
     # Start the server with output redirected to pipes
+    config_path = os.path.join(base_dir, "src", "config", "runtime_config.json")
     process = subprocess.Popen(
-        [server_path],
+        [server_path, config_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,  # Use text mode for easier output handling


### PR DESCRIPTION
## Summary
- add efficient batched writes in `BlockDeviceWAL`
- ensure e2e tests start server with default config path

## Testing
- `./run_tests.sh` in `tests/unit`
- `./run_tests.sh` in `tests/e2e`


------
https://chatgpt.com/codex/tasks/task_e_6865da9fd5488328be9a7e161ed0ab5e