### PR TITLE
Fix flaky tests by waiting for server shutdown

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,6 +23,17 @@ def wait_for_port(port, host="localhost", timeout=10.0):
             time.sleep(0.1)
     return False
 
+def wait_for_port_close(port, host="localhost", timeout=10.0):
+    """Wait for a port to become unavailable."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                time.sleep(0.1)
+        except OSError:
+            return True
+    return False
+
 @pytest.fixture(scope="session")
 def server_port():
     """Return a port number for the server."""

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,3 +1,4 @@
+protobuf>=4.25.3
 grpcio==1.60.0
 grpcio-tools==1.60.0
 pytest==7.4.3

--- a/tests/e2e/test_block_wal_persistence.py
+++ b/tests/e2e/test_block_wal_persistence.py
@@ -1,7 +1,6 @@
 import json
 import os
 import subprocess
-import time
 import grpc
 import tempfile
 
@@ -9,7 +8,7 @@ from conftest import wait_for_port
 
 import kvstore_pb2
 import kvstore_pb2_grpc
-
+from conftest import wait_for_port, wait_for_port_close
 
 
 def build_server():
@@ -56,7 +55,8 @@ def test_block_device_wal_persistence(tmp_path, server_port):
     channel.close()
     proc.terminate()
     proc.wait()
-    time.sleep(1)
+    if not wait_for_port_close(server_port, timeout=10):
+        raise RuntimeError("Server failed to shut down")
 
     proc = start_server(server_path, str(config_path), server_port)
     channel = grpc.insecure_channel(f"localhost:{server_port}")

--- a/tests/e2e/test_recovery_scenarios.py
+++ b/tests/e2e/test_recovery_scenarios.py
@@ -3,12 +3,23 @@ import os
 import struct
 import subprocess
 import time
+import socket
 import grpc
 
 import kvstore_pb2
 import kvstore_pb2_grpc
-from conftest import wait_for_port
+from conftest import wait_for_port, wait_for_port_close
 
+def wait_until_server_ready(port, timeout=10.0):
+    """Wait until we can connect to gRPC server on given port."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=0.5):
+                return True
+        except (ConnectionRefusedError, socket.timeout):
+            time.sleep(0.1)  # Small, consistent polling interval
+    return False
 
 def build_server():
     base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -54,8 +65,7 @@ def test_recover_from_crash(tmp_path, server_port):
     channel.close()
     proc.kill()  # simulate crash
     proc.wait()
-    time.sleep(1)
-
+    assert wait_until_server_ready(server_port)
     proc = start_server(server_path, str(config_path), server_port)
     channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)


### PR DESCRIPTION
## Summary
- replace fixed sleeps in E2E tests with dynamic waiting
- add `wait_for_port_close` helper to detect server shutdown

## Testing
- `./tests/e2e/run_tests.sh` *(fails: Server failed to start on port 50051)*

------
https://chatgpt.com/codex/tasks/task_e_6867050f6094832887c97575eebd4372