### PR TITLE
Make e2e test port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ More details are available in Folly's [installation guide](https://github.com/fa
    ```bash
    ./server
    ```
+   The server listens on port `50051` by default. To use a different port,
+   edit the `address` field in `src/config/runtime_config.json` or pass a
+   custom configuration file as the first argument when starting the server.
 8. In another terminal, run the client:
    ```bash
    ./client

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -2,6 +2,7 @@
 #include "wal_factory.h"
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <cstdlib>
 
 int main(int argc, char **argv) {
   std::string config_path = argc > 1 ? argv[1] : "src/config/runtime_config.json";

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,3 +15,10 @@ cd tests/e2e
 The server binary is built automatically if it does not already exist. Test
 results are shown in the console. The generated gRPC Python files and the
 virtual environment are created locally in this directory.
+
+The tests use port `50051` by default. Set the `KVSTORE_PORT` environment
+variable before running the tests to use a different port:
+
+```bash
+KVSTORE_PORT=60000 ./run_tests.sh
+```

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 import time
+import tempfile
+import json
 import pytest
 import grpc
 import socket
@@ -24,7 +26,7 @@ def wait_for_port(port, host="localhost", timeout=10.0):
 @pytest.fixture(scope="session")
 def server_port():
     """Return a port number for the server."""
-    return 50051
+    return int(os.environ.get("KVSTORE_PORT", "50051"))
 
 @pytest.fixture(scope="session")
 def server_process(server_port):
@@ -41,12 +43,20 @@ def server_process(server_port):
         subprocess.run(["cmake", "--build", build_dir], check=True)
     
     # Start the server with output redirected to pipes
+    config_src = os.path.join(base_dir, "src", "config", "runtime_config.json")
+    with open(config_src) as f:
+        config = json.load(f)
+    config["address"] = f"0.0.0.0:{server_port}"
+    temp_config = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".json")
+    json.dump(config, temp_config)
+    temp_config.close()
+
     process = subprocess.Popen(
-        [server_path],
+        [server_path, temp_config.name],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,  # Use text mode for easier output handling
-        bufsize=1   # Line buffered
+        bufsize=1  # Line buffered
     )
     
     # Wait for server to start
@@ -65,7 +75,7 @@ def server_process(server_port):
     print(f"Server started successfully on port {server_port}")
     
     yield process
-    
+
     # Cleanup
     process.terminate()
     try:
@@ -73,6 +83,7 @@ def server_process(server_port):
     except subprocess.TimeoutExpired:
         process.kill()
         process.wait()
+    os.unlink(temp_config.name)
 
 @pytest.fixture(scope="session")
 def grpc_channel(server_port, server_process):

--- a/tests/e2e/test_block_wal_persistence.py
+++ b/tests/e2e/test_block_wal_persistence.py
@@ -5,9 +5,11 @@ import time
 import grpc
 import tempfile
 
+from conftest import wait_for_port
+
 import kvstore_pb2
 import kvstore_pb2_grpc
-from conftest import wait_for_port
+
 
 
 def build_server():
@@ -20,7 +22,7 @@ def build_server():
     return server_path
 
 
-def start_server(server_path, config_path):
+def start_server(server_path, config_path, port):
     process = subprocess.Popen(
         [server_path, config_path],
         stdout=subprocess.PIPE,
@@ -28,7 +30,7 @@ def start_server(server_path, config_path):
         text=True,
         bufsize=1,
     )
-    if not wait_for_port(50051, timeout=10):
+    if not wait_for_port(port, timeout=10):
         out, err = process.communicate(timeout=1)
         process.terminate()
         process.wait()
@@ -36,19 +38,19 @@ def start_server(server_path, config_path):
     return process
 
 
-def test_block_device_wal_persistence(tmp_path):
+def test_block_device_wal_persistence(tmp_path, server_port):
     server_path = build_server()
     wal_file = tmp_path / "wal.log"
     config_path = tmp_path / "config.json"
     config = {
-        "address": "0.0.0.0:50051",
+        "address": f"0.0.0.0:{server_port}",
         "wal": {"type": "block", "device": str(wal_file)},
     }
     with open(config_path, "w") as f:
         json.dump(config, f)
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     assert stub.Put(kvstore_pb2.PutRequest(key=b"persist", value=b"value")).success
     channel.close()
@@ -56,8 +58,8 @@ def test_block_device_wal_persistence(tmp_path):
     proc.wait()
     time.sleep(1)
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     resp = stub.Get(kvstore_pb2.GetRequest(key=b"persist"))
     assert resp.found

--- a/tests/e2e/test_recovery_scenarios.py
+++ b/tests/e2e/test_recovery_scenarios.py
@@ -20,7 +20,7 @@ def build_server():
     return server_path
 
 
-def start_server(server_path, config_path):
+def start_server(server_path, config_path, port):
     process = subprocess.Popen(
         [server_path, config_path],
         stdout=subprocess.PIPE,
@@ -28,7 +28,7 @@ def start_server(server_path, config_path):
         text=True,
         bufsize=1,
     )
-    if not wait_for_port(50051, timeout=10):
+    if not wait_for_port(port, timeout=10):
         out, err = process.communicate(timeout=1)
         process.terminate()
         process.wait()
@@ -36,19 +36,19 @@ def start_server(server_path, config_path):
     return process
 
 
-def test_recover_from_crash(tmp_path):
+def test_recover_from_crash(tmp_path, server_port):
     server_path = build_server()
     wal_file = tmp_path / "wal.log"
     config_path = tmp_path / "config.json"
     config = {
-        "address": "0.0.0.0:50051",
+        "address": f"0.0.0.0:{server_port}",
         "wal": {"type": "block", "device": str(wal_file)},
     }
     with open(config_path, "w") as f:
         json.dump(config, f)
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     assert stub.Put(kvstore_pb2.PutRequest(key=b"crash", value=b"value")).success
     channel.close()
@@ -56,8 +56,8 @@ def test_recover_from_crash(tmp_path):
     proc.wait()
     time.sleep(1)
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     resp = stub.Get(kvstore_pb2.GetRequest(key=b"crash"))
     assert resp.found
@@ -67,19 +67,19 @@ def test_recover_from_crash(tmp_path):
     proc.wait()
 
 
-def test_recover_with_corrupt_wal(tmp_path):
+def test_recover_with_corrupt_wal(tmp_path, server_port):
     server_path = build_server()
     wal_file = tmp_path / "wal_corrupt.log"
     config_path = tmp_path / "config.json"
     config = {
-        "address": "0.0.0.0:50051",
+        "address": f"0.0.0.0:{server_port}",
         "wal": {"type": "block", "device": str(wal_file)},
     }
     with open(config_path, "w") as f:
         json.dump(config, f)
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     assert stub.Put(kvstore_pb2.PutRequest(key=b"good1", value=b"v1")).success
     assert stub.Put(kvstore_pb2.PutRequest(key=b"good2", value=b"v2")).success
@@ -94,8 +94,8 @@ def test_recover_with_corrupt_wal(tmp_path):
         f.write(struct.pack("<I", 4))
         f.write(b"bad")  # incomplete key
 
-    proc = start_server(server_path, str(config_path))
-    channel = grpc.insecure_channel("localhost:50051")
+    proc = start_server(server_path, str(config_path), server_port)
+    channel = grpc.insecure_channel(f"localhost:{server_port}")
     stub = kvstore_pb2_grpc.KeyValueStoreStub(channel)
     resp1 = stub.Get(kvstore_pb2.GetRequest(key=b"good1"))
     assert resp1.found and resp1.value == b"v1"


### PR DESCRIPTION
## Summary
- allow overriding server port via `KVSTORE_PORT`
- use the environment variable in e2e tests
- document the port option
- drop server environment variable override and use config file instead

## Testing
- `tests/e2e/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686705475b10832886bd69d5fdf5fa92