### PR TITLE
Fix server defaults without config

### DIFF
--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -12,6 +12,7 @@ int main(int argc, char **argv) {
     in >> config;
   } else {
     std::cerr << "Failed to open config " << config_path << ", using defaults\n";
+    config = nlohmann::json::object();
   }
 
   std::string address = config.value("address", "0.0.0.0:50051");

--- a/src/wal_factory.h
+++ b/src/wal_factory.h
@@ -6,11 +6,11 @@
 #include <nlohmann/json.hpp>
 
 inline std::unique_ptr<WAL> createWAL(const nlohmann::json &config) {
-  if (!config.contains("wal")) {
-    return std::make_unique<PassThroughWAL>();
-  }
-  auto walConfig = config["wal"];
-  std::string type = walConfig.value("type", "none");
+  const nlohmann::json &walConfig =
+      (config.contains("wal") && config["wal"].is_object())
+          ? config["wal"]
+          : nlohmann::json::object();
+  std::string type = walConfig.value("type", "block");
 
   if (type == "block") {
     if (walConfig.contains("device")) {
@@ -36,5 +36,6 @@ inline std::unique_ptr<WAL> createWAL(const nlohmann::json &config) {
       return std::make_unique<SpdkWAL>(defaultSpdkConfig);
     }
   }
-  return std::make_unique<PassThroughWAL>();
+  // Fallback to block device WAL for unknown or unspecified types
+  return std::make_unique<BlockDeviceWAL>("kvstore_block.wal");
 }

--- a/tests/unit/wal_factory_test.cpp
+++ b/tests/unit/wal_factory_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-TEST(WALFactoryTest, NoneCreatesPassThrough) {
+TEST(WALFactoryTest, NoneCreatesBlockDevice) {
   nlohmann::json cfg;
   auto wal = createWAL(cfg);
-  EXPECT_TRUE(dynamic_cast<PassThroughWAL *>(wal.get()) != nullptr);
+  EXPECT_TRUE(dynamic_cast<BlockDeviceWAL *>(wal.get()) != nullptr);
 }
 
 TEST(WALFactoryTest, BlockCreatesBlockDevice) {
@@ -40,9 +40,9 @@ TEST(WALFactoryTest, SpdkWithDefaultConfig) {
   EXPECT_TRUE(dynamic_cast<SpdkWAL *>(wal.get()) != nullptr);
 }
 
-TEST(WALFactoryTest, InvalidTypeCreatesPassThrough) {
+TEST(WALFactoryTest, InvalidTypeCreatesBlockDevice) {
   nlohmann::json cfg;
   cfg["wal"] = {{"type", "invalid_type"}};
   auto wal = createWAL(cfg);
-  EXPECT_TRUE(dynamic_cast<PassThroughWAL *>(wal.get()) != nullptr);
+  EXPECT_TRUE(dynamic_cast<BlockDeviceWAL *>(wal.get()) != nullptr);
 }


### PR DESCRIPTION
## Summary
- prevent crash when runtime config is missing
- default WAL type now uses block device WAL
- update WAL factory tests for new behaviour

## Testing
- `bash tests/unit/run_tests.sh`
- `./server`

------
https://chatgpt.com/codex/tasks/task_e_6867e0144e4483289ef59bda6dd40cdc