### PR TITLE
Fix coverage badge path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPDK Key-Value Store
 ![Unit Tests](https://github.com/manishym/kvstore/actions/workflows/c-cpp.yml/badge.svg)
-![Code Coverage](https://github.com/manishym/kvstore/actions/workflows/pr-code-coverage.yml/badge.svg)
+![Code Coverage](https://github.com/manishym/kvstore/actions/workflows/pr-code-coverage.yaml/badge.svg)
 
 This project implements a key-value store using SPDK and gRPC. It provides a simple API for storing, retrieving, and deleting key-value pairs.
 


### PR DESCRIPTION
## Summary
- fix README coverage badge link to match workflow file name

## Testing
- `./tests/unit/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686b7f585de48328a3d199dff639c8b1